### PR TITLE
検索表示画面の実装

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,4 @@
 github "kean/Nuke"
 github "mac-cain13/R.swift.Library"
+github "realm/realm-cocoa"
+

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
 github "kean/Nuke" "9.1.1"
 github "mac-cain13/R.swift.Library" "v5.2.0"
+github "realm/realm-cocoa" "v5.3.3"

--- a/intern_hackathon.xcodeproj/project.pbxproj
+++ b/intern_hackathon.xcodeproj/project.pbxproj
@@ -26,6 +26,10 @@
 		088E557D24D7190300A2FE3E /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088E557C24D7190300A2FE3E /* MainTabBarController.swift */; };
 		08C5FE2624CD7A8B007100CA /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C5FE2524CD7A8B007100CA /* Event.swift */; };
 		08EF05C524C37A6600129792 /* Rswift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 083FD71524C34D2300383122 /* Rswift.framework */; };
+		E00B8EA224E4CD6B00733DAF /* SearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E00B8EA024E4CD6B00733DAF /* SearchResultCell.swift */; };
+		E00B8EA324E4CD6B00733DAF /* SearchResultCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E00B8EA124E4CD6B00733DAF /* SearchResultCell.xib */; };
+		E04B13A324E3DD6900487A82 /* SearchResult.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E04B13A224E3DD6800487A82 /* SearchResult.storyboard */; };
+		E04B13A524E3DF9000487A82 /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04B13A424E3DF9000487A82 /* SearchResultViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +55,10 @@
 		088E557924D669AF00A2FE3E /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		088E557C24D7190300A2FE3E /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		08C5FE2524CD7A8B007100CA /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
+		E00B8EA024E4CD6B00733DAF /* SearchResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCell.swift; sourceTree = "<group>"; };
+		E00B8EA124E4CD6B00733DAF /* SearchResultCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchResultCell.xib; sourceTree = "<group>"; };
+		E04B13A224E3DD6800487A82 /* SearchResult.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SearchResult.storyboard; sourceTree = "<group>"; };
+		E04B13A424E3DF9000487A82 /* SearchResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -194,8 +202,20 @@
 		08CC377D24D9870200438D2F /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				E04B13A124E3DC5900487A82 /* SearchResult */,
 			);
 			path = Screen;
+			sourceTree = "<group>";
+		};
+		E04B13A124E3DC5900487A82 /* SearchResult */ = {
+			isa = PBXGroup;
+			children = (
+				E04B13A224E3DD6800487A82 /* SearchResult.storyboard */,
+				E04B13A424E3DF9000487A82 /* SearchResultViewController.swift */,
+				E00B8EA024E4CD6B00733DAF /* SearchResultCell.swift */,
+				E00B8EA124E4CD6B00733DAF /* SearchResultCell.xib */,
+			);
+			path = SearchResult;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -260,10 +280,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				088E557624D660B700A2FE3E /* SampleEventListCell.xib in Resources */,
+				E04B13A324E3DD6900487A82 /* SearchResult.storyboard in Resources */,
 				082CF75F24D569E7001F7680 /* SampleSearch.storyboard in Resources */,
 				083FD70C24C33D2B00383122 /* LaunchScreen.storyboard in Resources */,
 				083FD70924C33D2B00383122 /* Assets.xcassets in Resources */,
 				082CF76824D5A82F001F7680 /* SampleEventList.storyboard in Resources */,
+				E00B8EA324E4CD6B00733DAF /* SearchResultCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -335,6 +357,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E00B8EA224E4CD6B00733DAF /* SearchResultCell.swift in Sources */,
 				0841933724D9505800BFCBD3 /* Logger.swift in Sources */,
 				088E557A24D669AF00A2FE3E /* Array+Extensions.swift in Sources */,
 				083FD70024C33D2900383122 /* AppDelegate.swift in Sources */,
@@ -342,6 +365,7 @@
 				082CF76B24D5D526001F7680 /* APIClient.swift in Sources */,
 				082CF76324D59281001F7680 /* R.generated.swift in Sources */,
 				082CF76524D5A5B9001F7680 /* SampleEventListViewController.swift in Sources */,
+				E04B13A524E3DF9000487A82 /* SearchResultViewController.swift in Sources */,
 				088E557D24D7190300A2FE3E /* MainTabBarController.swift in Sources */,
 				08C5FE2624CD7A8B007100CA /* Event.swift in Sources */,
 				0841933924D950FF00BFCBD3 /* ErrorType.swift in Sources */,

--- a/intern_hackathon/Screen/Search/SearchViewController.swift
+++ b/intern_hackathon/Screen/Search/SearchViewController.swift
@@ -30,11 +30,11 @@ final class SearchViewController: UIViewController {
         APIClient.fetchEvents(keyword: text) { [ weak self] result in
             DispatchQueue.main.sync {
                 switch result {
-                    // 成功した場合
-                    case .success(let events):
+                // 成功した場合
+                case .success(let events):
                     self?.showEventListScreen(events)
-                    // 失敗した場合
-                    case .failure(let error):
+                // 失敗した場合
+                case .failure(let error):
                     let alert = UIAlertController.createErrorAlert(error)
                     self?.present(alert, animated: true)
                 }
@@ -45,7 +45,8 @@ final class SearchViewController: UIViewController {
     
     // EventScreenを表示する機能
     private func showEventListScreen(_ events: [Event]) {
-        print("eventScreen")
+        let searchResultViewController = SearchResultViewController.makeInstance(events)
+        navigationController?.pushViewController(searchResultViewController, animated: true)
     }
     
 }

--- a/intern_hackathon/Screen/SearchResult/SearchResult.storyboard
+++ b/intern_hackathon/Screen/SearchResult/SearchResult.storyboard
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="g9M-qM-tRc">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Search Result View Controller-->
+        <scene sceneID="Yzg-gs-dkJ">
+            <objects>
+                <viewController id="g9M-qM-tRc" customClass="SearchResultViewController" customModule="intern_hackathon" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ALS-TB-pF9">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="eXm-dr-uIf">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <connections>
+                                    <outlet property="dataSource" destination="g9M-qM-tRc" id="h4K-n9-yRp"/>
+                                    <outlet property="delegate" destination="g9M-qM-tRc" id="GQs-cv-3dc"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="eXm-dr-uIf" firstAttribute="bottom" secondItem="bHH-Sd-fPu" secondAttribute="bottom" id="KLX-kL-SFM"/>
+                            <constraint firstItem="eXm-dr-uIf" firstAttribute="top" secondItem="bHH-Sd-fPu" secondAttribute="top" id="PDt-es-33q"/>
+                            <constraint firstItem="eXm-dr-uIf" firstAttribute="trailing" secondItem="bHH-Sd-fPu" secondAttribute="trailing" id="b5v-B0-eKN"/>
+                            <constraint firstItem="eXm-dr-uIf" firstAttribute="leading" secondItem="bHH-Sd-fPu" secondAttribute="leading" id="hAX-yV-SOk"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="bHH-Sd-fPu"/>
+                    </view>
+                    <connections>
+                        <outlet property="tableView" destination="eXm-dr-uIf" id="lfG-Z1-KYR"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6UT-9X-vRs" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="47.826086956521742" y="84.375"/>
+        </scene>
+    </scenes>
+</document>

--- a/intern_hackathon/Screen/SearchResult/SearchResultCell.swift
+++ b/intern_hackathon/Screen/SearchResult/SearchResultCell.swift
@@ -1,0 +1,21 @@
+//
+//  SearchResultCell.swift
+//  intern_hackathon
+//
+//  Created by 渡辺泰平 on 2020/08/13.
+//  Copyright © 2020 caraquri. All rights reserved.
+//
+
+import UIKit
+
+class SearchResultCell: UITableViewCell {
+
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var descriptionLabel: UILabel!
+    
+    func set(_ event: Event) {
+        titleLabel.text = event.title
+        descriptionLabel.text = event.address
+    }
+    
+}

--- a/intern_hackathon/Screen/SearchResult/SearchResultCell.xib
+++ b/intern_hackathon/Screen/SearchResult/SearchResultCell.xib
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" restorationIdentifier="SearchResultCell" selectionStyle="default" indentationWidth="10" reuseIdentifier="searchResultCell" rowHeight="67" id="KGk-i7-Jjw" customClass="SearchResultCell" customModule="intern_hackathon" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="300" height="67"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="300" height="67"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FGW-mI-mkG" userLabel="Title">
+                        <rect key="frame" x="4" y="4" width="292" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QBI-AP-7jc" userLabel="Description">
+                        <rect key="frame" x="4" y="42" width="292" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="QBI-AP-7jc" secondAttribute="trailing" constant="4" id="2Nw-ur-rGn"/>
+                    <constraint firstItem="QBI-AP-7jc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="4" id="7mM-kg-Zv6"/>
+                    <constraint firstAttribute="trailing" secondItem="FGW-mI-mkG" secondAttribute="trailing" constant="4" id="QqL-Vz-1jM"/>
+                    <constraint firstAttribute="bottom" secondItem="QBI-AP-7jc" secondAttribute="bottom" constant="4" id="cgv-zB-tGG"/>
+                    <constraint firstItem="FGW-mI-mkG" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="4" id="kae-fv-xvh"/>
+                    <constraint firstItem="FGW-mI-mkG" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="4" id="qhj-ZJ-Qbc"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="descriptionLabel" destination="QBI-AP-7jc" id="w5x-Tf-1eV"/>
+                <outlet property="titleLabel" destination="FGW-mI-mkG" id="sWR-Vf-Dr3"/>
+            </connections>
+            <point key="canvasLocation" x="123.18840579710145" y="96.09375"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/intern_hackathon/Screen/SearchResult/SearchResultViewController.swift
+++ b/intern_hackathon/Screen/SearchResult/SearchResultViewController.swift
@@ -1,0 +1,60 @@
+//
+//  SearchResult.swift
+//  intern_hackathon
+//
+//  Created by 渡辺泰平 on 2020/08/12.
+//  Copyright © 2020 caraquri. All rights reserved.
+//
+
+import SafariServices
+import UIKit
+
+final class SearchResultViewController: UIViewController {
+    
+    @IBOutlet weak var tableView: UITableView!
+    private var events: [Event] = []
+
+    static func makeInstance(_ events: [Event]) -> SearchResultViewController {
+        let searchResultViewController = R.storyboard.searchResult.instantiateInitialViewController()!
+        searchResultViewController.events = events
+        return searchResultViewController
+    }
+    
+    override func viewDidLoad() {
+        tableView.register(R.nib.searchResultCell)
+        tableView.reloadData()
+    }
+}
+
+extension SearchResultViewController: UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return events.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: R.reuseIdentifier.searchResultCell, for: indexPath),
+            let event = events[safe: indexPath.row] else { return UITableViewCell() }
+        
+        cell.set(event)
+        return cell
+    }
+}
+
+extension SearchResultViewController: UITableViewDelegate {
+    
+    // height
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 60
+    }
+    
+    // select row
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let urlString = events[safe: indexPath.row]?.eventURL,
+            let url = URL(string: urlString) else { return }
+        
+        let safariViewController = SFSafariViewController(url: url)
+        present(safariViewController, animated: true)
+    }
+}


### PR DESCRIPTION
検索画面からイベントを受け取り、
- タイトルと内容のリストを表示する

- CellタップでSafariページを開く

![Simulator Screen Shot - iPhone 11 - 2020-08-13 at 12 18 01](https://user-images.githubusercontent.com/50143706/90090784-ddbcf000-dd5f-11ea-92cc-1b5601b9d869.png)
