### PR TITLE
イベント検索画面デザイン

### DIFF
--- a/intern_hackathon/AppDelegate.swift
+++ b/intern_hackathon/AppDelegate.swift
@@ -7,6 +7,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
+        // 選択済みのtabbar itemの色設定
+        UITabBar.appearance().tintColor = UIColor.white
+        
+        // 未選択のtabbar itemの色設定
+        UITabBar.appearance().unselectedItemTintColor = UIColor.white
+        
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = MainTabBarController()
         window?.makeKeyAndVisible()

--- a/intern_hackathon/Screen/Search/Search.storyboard
+++ b/intern_hackathon/Screen/Search/Search.storyboard
@@ -16,31 +16,46 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="キーワードを入力して検索" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tS4-u8-kd3">
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="キーワードを入力して検索" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tS4-u8-kd3">
                                 <rect key="frame" x="63" y="265" width="288" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="288" id="Fvp-Cl-J3Z"/>
+                                    <constraint firstAttribute="height" constant="34" id="JuL-ue-Egm"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="65t-5b-jzR">
-                                <rect key="frame" x="149" y="567" width="117" height="78"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="65t-5b-jzR">
+                                <rect key="frame" x="149" y="604" width="117" height="41"/>
+                                <color key="backgroundColor" red="0.05981048196554184" green="0.33046591281890869" blue="0.85459333658218384" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="41" id="JV2-Ic-5ZC"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                <state key="normal" title="検索"/>
+                                <state key="normal" title="検索">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
                                 <connections>
                                     <action selector="searchButtonTapped:" destination="lAv-ZW-wkZ" eventType="touchUpInside" id="qec-lV-ihr"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="キーワードを入力して下さい" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gsU-xT-8qB">
-                                <rect key="frame" x="42" y="307" width="331" height="40"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="キーワードを入力して下さい" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gsU-xT-8qB">
+                                <rect key="frame" x="88" y="307" width="238.5" height="21.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <color key="textColor" red="0.84937507398237433" green="0.23853189455357293" blue="0.14278816270735972" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="tS4-u8-kd3" firstAttribute="centerX" secondItem="65t-5b-jzR" secondAttribute="centerX" id="4VG-GA-0Mp"/>
+                            <constraint firstItem="gsU-xT-8qB" firstAttribute="top" secondItem="tS4-u8-kd3" secondAttribute="bottom" constant="8" id="Pvt-Wd-4UM"/>
+                            <constraint firstItem="tS4-u8-kd3" firstAttribute="centerX" secondItem="58h-k9-JIE" secondAttribute="centerX" id="Q0p-K0-KzU"/>
+                            <constraint firstItem="gsU-xT-8qB" firstAttribute="centerX" secondItem="58h-k9-JIE" secondAttribute="centerX" id="XWs-yr-Ytt"/>
+                            <constraint firstItem="7pw-8Z-LcC" firstAttribute="bottom" secondItem="65t-5b-jzR" secondAttribute="bottom" constant="168" id="fbW-ao-ew4"/>
+                            <constraint firstItem="65t-5b-jzR" firstAttribute="leading" secondItem="7pw-8Z-LcC" secondAttribute="leading" constant="149" id="m6h-DZ-KL5"/>
+                            <constraint firstItem="tS4-u8-kd3" firstAttribute="top" secondItem="7pw-8Z-LcC" secondAttribute="top" constant="177" id="ylh-f6-0jW"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="7pw-8Z-LcC"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="検索" image="magnifyingglass" catalog="system" selectedImage="magnifyingglass" id="vft-4j-13R"/>
@@ -54,7 +69,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KYy-C9-MMG" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="900" y="159"/>
+            <point key="canvasLocation" x="900.00000000000011" y="158.70535714285714"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="ev8-kY-4kK">

--- a/intern_hackathon/Screen/Search/SearchViewController.swift
+++ b/intern_hackathon/Screen/Search/SearchViewController.swift
@@ -15,7 +15,35 @@ final class SearchViewController: UIViewController {
     @IBOutlet weak var searchButton: UIButton!
     
     override func viewDidLoad() {
-            label.isHidden = true
+        // navbarの色設定
+        navigationController?.navigationBar.barTintColor = UIColor(red: 109 / 255, green: 185 / 255, blue: 208 / 255, alpha: 100)
+        
+        // navbarの文字色
+        self.navigationController?.navigationBar.titleTextAttributes = [
+            .foregroundColor: UIColor.white
+        ]
+        
+        // tabbarの色設定
+        tabBarController?.tabBar.barTintColor = UIColor(red: 109 / 255, green: 185 / 255, blue: 208 / 255, alpha: 100)
+        
+//        // 常にライトモード（明るい外観）を指定することでダークモード適用を回避
+//        self.overrideUserInterfaceStyle = .light
+//
+        
+        label.isHidden = true
+        
+        // 角丸
+        searchButton.layer.cornerRadius = 10.0
+        // 背景色
+        searchButton.backgroundColor = UIColor(red: 77 / 255, green: 147 / 255, blue: 182 / 255, alpha: 100)
+        // 影
+        searchButton.layer.shadowOpacity = 0.16
+        searchButton.layer.shadowRadius = 2.0
+        searchButton.layer.shadowColor = UIColor.black.cgColor
+        searchButton.layer.shadowOffset = CGSize(width: 0, height: 3.0)
+        searchButton.layer.borderWidth = 2.0
+        searchButton.layer.borderColor = UIColor.clear.cgColor
+            
     }
     
     @IBAction func searchButtonTapped(_ sender: UIButton) {


### PR DESCRIPTION
イベント検索画面のtextFieldの文字を黒くし、NavigationBarやTabBar、TabItemの色を変更しました。
![Simulator Screen Shot - iPhone 11 - 2020-08-14 at 15 00 17](https://user-images.githubusercontent.com/55826743/90218494-e801eb80-de3e-11ea-8e39-48b18257ba98.png)
